### PR TITLE
Address issues in Workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,14 +33,23 @@ jobs:
         sed -i "s|{{__source__}}|${source}|g" PKGBUILD
         sed -i "s|{{__source_hash__}}|${source_hash}|g" PKGBUILD
         sed -i "s|{{__version__}}|${version}|g" PKGBUILD
-        docker pull archlinux:latest
-        docker run --rm -v $(pwd):/pkg -w /pkg archlinux:latest bash -c "pacman -Sy --noconfirm base-devel fuse2 && useradd -u $(id -u) runner && su runner -s /bin/sh -c 'makepkg -sf && makepkg --printsrcinfo > .SRCINFO'"
+        wget -O /tmp/PKGBUILD.old "https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=warcraftlogsuploader"
+        if ! diff /tmp/PKGBUILD.old PKGBUILD > /dev/null; then
+          rm -f /tmp/PKGBUILD.old
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+        else
+          rm -f /tmp/PKGBUILD.old
+          docker pull archlinux:latest
+          docker run --rm -v $(pwd):/pkg -w /pkg archlinux:latest bash -c "pacman -Sy --noconfirm base-devel fuse2 && useradd -u $(id -u) runner && su runner -s /bin/sh -c 'makepkg -sf && makepkg --printsrcinfo > .SRCINFO'"
+        fi
 
     - name: Configure Git
       run: |
         mkdir -p ~/.ssh
-        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/aur
+        touch ~/.ssh/aur
         chmod 600 ~/.ssh/aur
+        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/aur
         git config --global --add safe.directory $(pwd)
         git config --global user.email "mr@deltachaos.de"
         git config --global user.name "Maximilian Ruta"
@@ -66,4 +75,4 @@ jobs:
         fi
       env:
         GIT_SSH_COMMAND: "ssh -i ~/.ssh/aur -o StrictHostKeyChecking=accept-new"
-    - uses: gautamkrishnar/keepalive-workflow@v2
+    - uses: Entepotenz/keep-github-actions-alive-min-dependencies@v1


### PR DESCRIPTION
Action gautamkrishnar/keepalive-workflow@v2 was removed from Github. It seems valid replacement seems to be Entepotenz/keep-github-actions-alive-min-dependencies@v1.

In addition I removed small window when Private SSH key is group readable and make Workflow to cancel early (saving docker pull and docker run at very least), to limit use of GH resources